### PR TITLE
Remove duplicate previous hostname entry Before adding host entry.

### DIFF
--- a/Custom/GraniResource/DSCResources/Grani_HostsFile/Grani_HostsFile.psm1
+++ b/Custom/GraniResource/DSCResources/Grani_HostsFile/Grani_HostsFile.psm1
@@ -29,6 +29,8 @@ Data VerboseMessages {
         HostsEntryFound = Found a hosts entry {0} : {1}.
         HostsEntryNotFound = Did not find a hosts entry {0} : {1}.
         RemoveHostsEntry = Remove hosts entry {0} : {1}.
+        RemoveHostsEntryBeforeAdd = Remove duplicate hostname entry before adding host entry. This will ignore IPAddress because correct host entry will add right after remove. hostname : {0}
+        RemovedEntryIP = Removed Entry for {0} : {1}.{2}.{3}.{4}
 "@
 }
 
@@ -119,10 +121,15 @@ function Set-TargetResource
             ((Get-Content $script:hostsLocation) -notmatch "^\s*$") -notmatch "^[^#]*$IpAddress\s+$HostName" | Set-Content -Path $script:hostsLocation -Force -Encoding $script:encoding
             return;
         }
+        else
+        {
+            # Present
+            Write-Verbose ($VerboseMessages.RemoveHostsEntryBeforeAdd -f $HostName)
+            ((Get-Content $script:hostsLocation) -notmatch "^\s*$") -notmatch "^[^#]*(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\s+$HostName" | Set-Content -Path $script:hostsLocation -Force -Encoding $script:encoding
 
-        # Present
-        Write-Verbose ($VerboseMessages.CreateHostsEntry -f $HostName, $IpAddress)
-        Add-Content -Path $script:hostsLocation -Value $hostEntry -Force -Encoding $script:encoding
+            Write-Verbose ($VerboseMessages.CreateHostsEntry -f $HostName, $IpAddress)
+            Add-Content -Path $script:hostsLocation -Value $hostEntry -Force -Encoding $script:encoding
+        }
     }
     catch
     {

--- a/Custom/Test/DSCResources/Grani_HostsFile/TargetResourceJoin.Tests.ps1
+++ b/Custom/Test/DSCResources/Grani_HostsFile/TargetResourceJoin.Tests.ps1
@@ -6,6 +6,7 @@ Describe "Grani_HostsFile : *-TargetResource" {
 
     $hostName = "google.com"
     $ipAddress = "8.8.8.8"
+    $newIPAddress = "8.8.6.6"
     $present = "Present"
     $absent = "Absent"
 
@@ -44,21 +45,39 @@ Describe "Grani_HostsFile : *-TargetResource" {
         }
    }
 
-    Context "Already configured environment. Remove HostEntry " {
-        It "Test-TargetResource should return true" {
-            Test-TargetResource -HostName $hostName -IpAddress $ipAddress -Ensure $present | should be $true
+    Context "Already configured environment. Enter different IP with same HostEntry " {
+        It "Test-TargetResource should return false" {
+            Test-TargetResource -HostName $hostName -IpAddress $newIPAddress -Ensure $present | should be $false
         }
 
         It "Set-TargetResource should not Throw" {
-            {Set-TargetResource -HostName $hostName -IpAddress $ipAddress -Ensure $absent} | should not Throw
+            {Set-TargetResource -HostName $hostName -IpAddress $newIPAddress -Ensure $present} | should not Throw
         }
 
-        It "Get-TargetResource should return Ensure : Absent" {
-            (Get-TargetResource -HostName $hostName -IpAddress $ipAddress -Ensure $absent).Ensure | should be ([EnsureType]::Absent.ToString())
+        It "Get-TargetResource should return Ensure : Present" {
+            (Get-TargetResource -HostName $hostName -IpAddress $newIPAddress -Ensure $present).Ensure | should be ([EnsureType]::Present.ToString())
         }
 
         It "Test-TargetResource should return true" {
-            Test-TargetResource -HostName $hostName -IpAddress $ipAddress -Ensure $absent | should be $true
+            Test-TargetResource -HostName $hostName -IpAddress $newIPAddress -Ensure $present | should be $true
+        }
+    }
+
+    Context "Already configured environment. Remove HostEntry " {
+        It "Test-TargetResource should return true" {
+            Test-TargetResource -HostName $hostName -IpAddress $newIPAddress -Ensure $present | should be $true
+        }
+
+        It "Set-TargetResource should not Throw" {
+            {Set-TargetResource -HostName $hostName -IpAddress $newIPAddress -Ensure $absent} | should not Throw
+        }
+
+        It "Get-TargetResource should return Ensure : Absent" {
+            (Get-TargetResource -HostName $hostName -IpAddress $newIPAddress -Ensure $absent).Ensure | should be ([EnsureType]::Absent.ToString())
+        }
+
+        It "Test-TargetResource should return true" {
+            Test-TargetResource -HostName $hostName -IpAddress $newIPAddress -Ensure $absent | should be $true
         }
     }
 }


### PR DESCRIPTION
Issue : https://github.com/guitarrapc/DSCResources/issues/36

Description
----

Previously new host entry added to last. This apply even which already same host name different ip entry is exists. .

This is obviously bad as expected to be run added entry but never.